### PR TITLE
Fixed typo in "Sending Transaction" error handler

### DIFF
--- a/docs/guide/sending-transactions.md
+++ b/docs/guide/sending-transactions.md
@@ -64,7 +64,7 @@ sendEthButton.addEventListener('click', () => {
       ],
     })
     .then((txHash) => console.log(txHash))
-    .catch((error) => console.error);
+    .catch((error) => console.error(error));
 });
 
 ethereumButton.addEventListener('click', () => {


### PR DESCRIPTION
Hi, I found a typo while playing with example from ["Sending Transactions" page](https://docs.metamask.io/guide/sending-transactions.html#example)

Current version of error handler does nothing:
```javascript
.catch((error) => console.error);
```

But it probably should print an error, and be like:
```javascript
.catch((error) => console.error(error));
```